### PR TITLE
Potential fix for code scanning alert no. 12: Full server-side request forgery

### DIFF
--- a/backend/app/api/v1/endpoints/piles.py
+++ b/backend/app/api/v1/endpoints/piles.py
@@ -519,11 +519,12 @@ async def validate_url(url: str = Form(...)) -> Dict[str, Any]:
             }
         # Check if the resolved IP is private or loopback
         parsed_ip = ipaddress.ip_address(resolved_ip)
-        if parsed_ip.is_private or parsed_ip.is_loopback:
+        if (parsed_ip.is_private or parsed_ip.is_loopback or 
+            parsed_ip.is_link_local or parsed_ip.is_unspecified or parsed_ip.is_multicast):
             return {
                 "success": False,
                 "valid": False,
-                "message": "Access to private or loopback IPs is not allowed"
+                "message": "Access to private, loopback, link-local, unspecified, or multicast IPs is not allowed"
             }
         async with aiohttp.ClientSession() as session:
             async with session.get(url, timeout=aiohttp.ClientTimeout(total=10), allow_redirects=True) as response:

--- a/backend/app/api/v1/endpoints/piles.py
+++ b/backend/app/api/v1/endpoints/piles.py
@@ -494,11 +494,11 @@ async def validate_url(url: str = Form(...)) -> Dict[str, Any]:
         # Use the module-level constant for allowed domains
         allowed_domains = ALLOWED_DOMAINS
         parsed_url = urlparse(url)
-        if not parsed_url.scheme or not parsed_url.netloc:
+        if not parsed_url.scheme or not parsed_url.netloc or parsed_url.scheme not in ('http', 'https'):
             return {
                 "success": False,
                 "valid": False,
-                "message": "Invalid URL format"
+                "message": "Invalid URL format or unsupported scheme. Only 'http' and 'https' are allowed."
             }
         # Resolve the hostname to an IP address
         hostname = parsed_url.hostname

--- a/backend/app/api/v1/endpoints/piles.py
+++ b/backend/app/api/v1/endpoints/piles.py
@@ -502,7 +502,7 @@ async def validate_url(url: str = Form(...)) -> Dict[str, Any]:
         # Resolve the hostname to an IP address
         hostname = parsed_url.hostname
         try:
-            resolved_ips = [addr[4][0] for addr in await asyncio.get_event_loop().getaddrinfo(hostname, None)]
+            resolved_ips = [addr[4][0] for addr in await asyncio.getaddrinfo(hostname, None)]
         except socket.gaierror:
             return {
                 "success": False,

--- a/backend/app/api/v1/endpoints/piles.py
+++ b/backend/app/api/v1/endpoints/piles.py
@@ -492,7 +492,6 @@ async def validate_url(url: str = Form(...)) -> Dict[str, Any]:
     """Validate if a URL is accessible"""
     try:
         # Use the module-level constant for allowed domains
-        allowed_domains = ALLOWED_DOMAINS
         parsed_url = urlparse(url)
         if not parsed_url.scheme or not parsed_url.netloc or parsed_url.scheme not in ('http', 'https'):
             return {

--- a/backend/app/api/v1/endpoints/piles.py
+++ b/backend/app/api/v1/endpoints/piles.py
@@ -511,7 +511,7 @@ async def validate_url(url: str = Form(...)) -> Dict[str, Any]:
                 "message": "DNS resolution failed for the hostname"
             }
         # Check if the domain is in the allowed list
-        if not any(hostname.endswith(f".{domain}") or hostname == domain for domain in allowed_domains):
+        if not any(hostname.lower().endswith(f".{domain.lower()}") or hostname.lower() == domain.lower() for domain in allowed_domains):
             return {
                 "success": False,
                 "valid": False,

--- a/backend/app/api/v1/endpoints/piles.py
+++ b/backend/app/api/v1/endpoints/piles.py
@@ -511,7 +511,7 @@ async def validate_url(url: str = Form(...)) -> Dict[str, Any]:
                 "message": "DNS resolution failed for the hostname"
             }
         # Check if the domain is in the allowed list
-        if hostname not in allowed_domains:
+        if not any(hostname.endswith(f".{domain}") or hostname == domain for domain in allowed_domains):
             return {
                 "success": False,
                 "valid": False,

--- a/backend/app/api/v1/endpoints/piles.py
+++ b/backend/app/api/v1/endpoints/piles.py
@@ -510,7 +510,9 @@ async def validate_url(url: str = Form(...)) -> Dict[str, Any]:
                 "message": "Domain not allowed"
             }
         # Check if the resolved IP is private or loopback
-        if resolved_ip.startswith("10.") or resolved_ip.startswith("192.168.") or resolved_ip.startswith("172.") or resolved_ip == "127.0.0.1":
+        import ipaddress
+        parsed_ip = ipaddress.ip_address(resolved_ip)
+        if parsed_ip.is_private or parsed_ip.is_loopback:
             return {
                 "success": False,
                 "valid": False,

--- a/backend/app/api/v1/endpoints/piles.py
+++ b/backend/app/api/v1/endpoints/piles.py
@@ -490,8 +490,9 @@ async def download_pile_source(
 @router.post("/validate-url")
 async def validate_url(url: str = Form(...)) -> Dict[str, Any]:
     """Validate if a URL is accessible"""
-    allowed_domains = {"example.com", "another-allowed-domain.com"}
     try:
+        # Use the module-level constant for allowed domains
+        allowed_domains = ALLOWED_DOMAINS
         parsed_url = urlparse(url)
         if not parsed_url.scheme or not parsed_url.netloc:
             return {

--- a/backend/app/api/v1/endpoints/piles.py
+++ b/backend/app/api/v1/endpoints/piles.py
@@ -518,7 +518,6 @@ async def validate_url(url: str = Form(...)) -> Dict[str, Any]:
                 "message": "Domain not allowed"
             }
         # Check if the resolved IP is private or loopback
-        import ipaddress
         parsed_ip = ipaddress.ip_address(resolved_ip)
         if parsed_ip.is_private or parsed_ip.is_loopback:
             return {

--- a/backend/app/api/v1/endpoints/piles.py
+++ b/backend/app/api/v1/endpoints/piles.py
@@ -502,7 +502,14 @@ async def validate_url(url: str = Form(...)) -> Dict[str, Any]:
             }
         # Resolve the hostname to an IP address
         hostname = parsed_url.hostname
-        resolved_ip = (await asyncio.get_event_loop().getaddrinfo(hostname, None))[0][4][0]
+        try:
+            resolved_ip = (await asyncio.get_event_loop().getaddrinfo(hostname, None))[0][4][0]
+        except socket.gaierror:
+            return {
+                "success": False,
+                "valid": False,
+                "message": "DNS resolution failed for the hostname"
+            }
         # Check if the domain is in the allowed list
         if hostname not in allowed_domains:
             return {

--- a/backend/app/api/v1/endpoints/piles.py
+++ b/backend/app/api/v1/endpoints/piles.py
@@ -527,15 +527,6 @@ async def validate_url(url: str = Form(...)) -> Dict[str, Any]:
                 "valid": False,
                 "message": "Domain not allowed"
             }
-        # Check if the resolved IP is private or loopback
-        parsed_ip = ipaddress.ip_address(resolved_ip)
-        if (parsed_ip.is_private or parsed_ip.is_loopback or 
-            parsed_ip.is_link_local or parsed_ip.is_unspecified or parsed_ip.is_multicast):
-            return {
-                "success": False,
-                "valid": False,
-                "message": "Access to private, loopback, link-local, unspecified, or multicast IPs is not allowed"
-            }
         async with aiohttp.ClientSession() as session:
             async with session.get(url, timeout=aiohttp.ClientTimeout(total=10), allow_redirects=True) as response:
                 if response.status == 200:


### PR DESCRIPTION
Potential fix for [https://github.com/VictoKu1/babylonpiles/security/code-scanning/12](https://github.com/VictoKu1/babylonpiles/security/code-scanning/12)

To fix the issue, we need to validate and restrict the `url` parameter to prevent SSRF attacks. The best approach is to maintain a whitelist of allowed domains or subdomains and ensure the user-provided URL resolves to one of these domains. Additionally, we should verify that the resolved IP address is not private or loopback to prevent access to internal services.

Steps to implement the fix:
1. Parse the user-provided URL using `urllib.parse`.
2. Resolve the hostname to an IP address and ensure it matches a whitelist of allowed domains or subdomains.
3. Check that the resolved IP address is not private or loopback.
4. Only proceed with the HTTP request if all validations pass.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
